### PR TITLE
feat: day 12 hardening - switch to STF reusable checks

### DIFF
--- a/.github/workflows/tf-checks.yml
+++ b/.github/workflows/tf-checks.yml
@@ -6,12 +6,14 @@ on:
   workflow_dispatch:
 jobs:
   basic-example:
-    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@88efd7724e007c8f721a219498be29e0c9ad471b # pinned to latest
+    uses: clouddrove/github-shared-workflows/.github/workflows/stf-checks.yml@c615ea7ef3e5beba98a335bf9acce8e67e03c755 # pinned to latest
     with:
+      provider: digitalocean
       working_directory: './_examples/basic/'
   complete-example:
-    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@88efd7724e007c8f721a219498be29e0c9ad471b # pinned to latest
+    uses: clouddrove/github-shared-workflows/.github/workflows/stf-checks.yml@c615ea7ef3e5beba98a335bf9acce8e67e03c755 # pinned to latest
     with:
+      provider: digitalocean
       working_directory: './_examples/complete/'
 
 # Seperate Job for TFlint workflow call


### PR DESCRIPTION
## Summary
- Day 12 implementation for DO Project #2 in `terraform-digitalocean-domain`.
- Replaced reusable workflow call(s) from `tf-checks.yml` to `stf-checks.yml`.
- Kept reusable workflow source policy compliant: only `clouddrove/github-shared-workflows` is used.
- Added explicit `provider: digitalocean` inputs for STF reusable workflow jobs.

## Validation
- Opened as implementation PR for board tracking.
- CI/pre-validation checks are running after PR creation.
- No merge performed.